### PR TITLE
Spacing and newline edits

### DIFF
--- a/transpiler/transpile.go
+++ b/transpiler/transpile.go
@@ -320,7 +320,7 @@ func (t *Transpiler) Transpile(node ast.Node) ast.Node {
 			}
 
 			if i < len(node.Parameters)-1 {
-				t.addCode(",")
+				t.addCode(", ")
 			}
 		}
 
@@ -379,7 +379,7 @@ func (t *Transpiler) Transpile(node ast.Node) ast.Node {
 
 	case *ast.CallExpression:
 		t.transpileCallExpression(node)
-		t.addNewLine()
+		//t.addNewLine() // avoid newline after return(x)
 	}
 
 	return node

--- a/vapour.go
+++ b/vapour.go
@@ -16,7 +16,7 @@ type vapour struct {
 func New() *vapour {
 	return &vapour{
 		name:    "vapour",
-		version: "0.0.5",
+		version: "0.0.6",
 	}
 }
 


### PR DESCRIPTION
Feel free to ignore this - I just wanted to play around with it and see if I could fix a very minor annoyance.

With this toy vapour code

```rust
func foo(a: int = 1, b: char = "", c:char = ""): int {
    return paste(b, c, a)
}

let bar: int = foo(0, "Hello, ", "World!")
```

I get this result

vapour@0.0.5
```r
foo = function(a = 1,b = "",c = "") {
return(paste(b, c, a)
)
}
bar = foo(0, "Hello, ", "World!")
```

With the minor changes in this PR, I get

vapour@0.0.6
```r
foo = function(a = 1, b = "", c = "") {
return(paste(b, c, a))
}
bar = foo(0, "Hello, ", "World!")
```

- spaces after each term in the function signature
- no newline breaking the `return()`

I have not tested what else this changes or if this is even the right place to make these changes. Actually, I'm fairly sure it's not for the extra newline; it happens for other functions containing expressions, too.

One option would be to style the generated R file with e.g. {styler} which would take care of any inconsistencies from transpilation, e.g. dealing with indentation which sounds like a whole world of trouble. Running `styler::style_file("R/vapour.R")` over the file generated by vapour@0.0.5 produces

```r
foo <- function(a = 1, b = "", c = "") {
  return(paste(b, c, a))
}
bar <- foo(0, "Hello, ", "World!")
```

which appears to have fixed both issues.